### PR TITLE
doc: Add missing trailing code fences in crates README

### DIFF
--- a/microBioRust/README.md
+++ b/microBioRust/README.md
@@ -25,6 +25,7 @@ pub fn genbank_to_faa(filename: &str) -> Result<(), anyhow::Error> {
     }
     return Ok(());
 }
+```
 
 better for debugging
 


### PR DESCRIPTION
Noticed this lack of code block separation in the crate README:

<img width="760" height="542" alt="Google Chrome 2025-11-06 13 33 06" src="https://github.com/user-attachments/assets/1ebb8542-9cc3-4837-9432-cd7abbaa807e" />
